### PR TITLE
Add bearer token support for token server requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ This is the hook that makes this package to work. `Options` is an object that co
 - **redirectUri** (string): Determines where the 3rd party API server redirects the user after the user completes the authorization flow. In our [example](#usage-example) the Popup is rendered on that redirectUri.
 - **scope** (string - _optional_): A list of scopes depending on your application needs.
 - **responseType** (string): Can be either **code** for _code authorization grant_ or **token** for _implicit grant_.
-- **extraQueryParameters** (string - _optional_): An object of extra parameters that you'd like to pass to the query part of the authorizeUrl, e.g {audience: "xyz"}.
+- **extraQueryParameters** (object - _optional_): An object of extra parameters that you'd like to pass to the query part of the authorizeUrl, e.g {audience: "xyz"}.
 - **exchangeCodeForTokenServerURL** (string): This property is only used when using _code authorization grant_ flow (responseType = code). It specifies the API URL of your server that will get called immediately after the user completes the authorization flow. Read more [here](#what-is-the-purpose-of-exchangecodefortokenserverurl-for-authorization-code-flows).
 - **exchangeCodeForTokenMethod** (string - _optional_): Specifies the HTTP method that will be used for the code-for-token exchange to your server. Defaults to **POST**.
-- **exchangeCodeForTokenHeaders** (string - _optional_): An object of extra parameters that will be used for the code-for-token exchange to your server.
+- **exchangeCodeForTokenHeaders** (object - _optional_): An object of extra parameters that will be used for the code-for-token exchange to your server.
 - **onSuccess** (function): Called after a complete successful authorization flow.
 - **onError** (function): Called when an error occurs.
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ This is the hook that makes this package to work. `Options` is an object that co
 - **extraQueryParameters** (string - _optional_): An object of extra parameters that you'd like to pass to the query part of the authorizeUrl, e.g {audience: "xyz"}.
 - **exchangeCodeForTokenServerURL** (string): This property is only used when using _code authorization grant_ flow (responseType = code). It specifies the API URL of your server that will get called immediately after the user completes the authorization flow. Read more [here](#what-is-the-purpose-of-exchangecodefortokenserverurl-for-authorization-code-flows).
 - **exchangeCodeForTokenMethod** (string - _optional_): Specifies the HTTP method that will be used for the code-for-token exchange to your server. Defaults to **POST**.
+- **exchangeCodeForTokenHeaders** (string - _optional_): An object of extra parameters that will be used for the code-for-token exchange to your server.
 - **onSuccess** (function): Called after a complete successful authorization flow.
 - **onError** (function): Called when an error occurs.
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ## Features
 
-- Usage with both `Implicit` and `Authorization Code` grant flows.
-- Seamlessly **exchanges code for token** via your backend API URL, for authorization code grant flows.
-- Works with **Popup** authorization.
-- Provides data and loading/error states via a hook.
-- **Persists data** to localStorage and automatically syncs auth state between tabs and/or browser windows.
+-   Usage with both `Implicit` and `Authorization Code` grant flows.
+-   Seamlessly **exchanges code for token** via your backend API URL, for authorization code grant flows.
+-   Works with **Popup** authorization.
+-   Provides data and loading/error states via a hook.
+-   **Persists data** to localStorage and automatically syncs auth state between tabs and/or browser windows.
 
 ## Install
 
@@ -28,71 +28,70 @@ npm i @tasoskakour/react-use-oauth2
 
 ## Usage example
 
-*For authorization code flow:*
+_For authorization code flow:_
 
 ```js
-import { OAuth2Popup, useOAuth2 } from "@tasoskakour/react-use-oauth2";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { OAuth2Popup, useOAuth2 } from '@tasoskakour/react-use-oauth2';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 const Home = () => {
-  const { data, loading, error, getAuth, logout } = useOAuth2({
-    authorizeUrl: "https://example.com/auth",
-    clientId: "YOUR_CLIENT_ID",
-    redirectUri: `${document.location.origin}/callback`,
-    scope: "YOUR_SCOPES",
-    responseType: "code",
-    exchangeCodeForTokenServerURL: "https://your-backend/token",
-    exchangeCodeForTokenMethod: "POST",
-    onSuccess: (payload) => console.log("Success", payload),
-    onError: (error_) => console.log("Error", error_)
-  });
+	const { data, loading, error, getAuth, logout } = useOAuth2({
+		authorizeUrl: 'https://example.com/auth',
+		clientId: 'YOUR_CLIENT_ID',
+		redirectUri: `${document.location.origin}/callback`,
+		scope: 'YOUR_SCOPES',
+		responseType: 'code',
+		exchangeCodeForTokenServerURL: 'https://your-backend/token',
+		exchangeCodeForTokenMethod: 'POST',
+		onSuccess: (payload) => console.log('Success', payload),
+		onError: (error_) => console.log('Error', error_),
+	});
 
-  const isLoggedIn = Boolean(data?.access_token); // or whatever...
+	const isLoggedIn = Boolean(data?.access_token); // or whatever...
 
-  if (error) {
-    return <div>Error</div>;
-  }
+	if (error) {
+		return <div>Error</div>;
+	}
 
-  if (loading) {
-    return <div>Loading...</div>;
-  }
+	if (loading) {
+		return <div>Loading...</div>;
+	}
 
-  if (isLoggedIn) {
-    return (
-      <div>
-        <pre>{JSON.stringify(data)}</pre>
-        <button onClick={logout}>Logout</button>
-      </div>
-    )
-  }
+	if (isLoggedIn) {
+		return (
+			<div>
+				<pre>{JSON.stringify(data)}</pre>
+				<button onClick={logout}>Logout</button>
+			</div>
+		);
+	}
 
-  return (
-    <button style={{ margin: "24px" }} type="button" onClick={() => getAuth()}>
-      Login
-    </button>
-  );
+	return (
+		<button style={{ margin: '24px' }} type="button" onClick={() => getAuth()}>
+			Login
+		</button>
+	);
 };
 
 const App = () => {
-  return (
-    <BrowserRouter>
-      <Routes>
-        <Route element={<OAuthPopup />} path="/callback" />
-        <Route element={<Home />} path="/" />
-      </Routes>
-    </BrowserRouter>
-  );
+	return (
+		<BrowserRouter>
+			<Routes>
+				<Route element={<OAuthPopup />} path="/callback" />
+				<Route element={<Home />} path="/" />
+			</Routes>
+		</BrowserRouter>
+	);
 };
 ```
 
 ### What is the purpose of `exchangeCodeForTokenServerURL` for Authorization Code flows?
 
-Generally when we're working with authorization code flows, we need to *immediately* **exchange** the retrieved *code* with an actual *access token*, after a successful authorization. Most of the times this is needed for back-end apps, but there are many use cases this is useful for front-end apps as well. 
+Generally when we're working with authorization code flows, we need to _immediately_ **exchange** the retrieved _code_ with an actual _access token_, after a successful authorization. Most of the times this is needed for back-end apps, but there are many use cases this is useful for front-end apps as well.
 
-In order for the flow to be accomplished, the 3rd party provider we're authorizing against (e.g Google, Facebook etc), will provide an API call (e.g for Google is `https://oauth2.googleapis.com/token`) that we need to hit in order to exchange the code for an access token. However, this call requires the `client_secret` of your 3rd party app as a parameter to work - a secret that you cannot expose to your front-end app. 
+In order for the flow to be accomplished, the 3rd party provider we're authorizing against (e.g Google, Facebook etc), will provide an API call (e.g for Google is `https://oauth2.googleapis.com/token`) that we need to hit in order to exchange the code for an access token. However, this call requires the `client_secret` of your 3rd party app as a parameter to work - a secret that you cannot expose to your front-end app.
 
-That's why you need to proxy this call to your back-end and `exchangeCodeForTokenServerURL` is the API URL of your back-end route that will take care of this. The request parameters that will get passed along as **query parameters** are `{ code, client_id, grant_type, redirect_uri, state }`. By default this will be a **POST** request but you can change it with the `exchangeCodeForTokenMethod` property. 
-
+That's why you need to proxy this call to your back-end and `exchangeCodeForTokenServerURL` is the API URL of your back-end route that will take care of this. The request parameters that will get passed along as **query parameters** are `{ code, client_id, grant_type, redirect_uri, state }`. By default this will be a **POST** request but you can change it with the `exchangeCodeForTokenMethod` property. In case your backend requires a bearer token for authorization, you can pass it through `exchangeCodeForTokenBearerToken`.
 
 You can read more about "Exchanging authorization code for refresh and access tokens" in [Google OAuth2 documentation](https://developers.google.com/identity/protocols/oauth2/web-server#exchange-authorization-code).
 
@@ -102,7 +101,7 @@ With an implicit grant flow things are much simpler as the 3rd-party provider im
 
 ### Data persistence
 
-After a successful authorization, data will get persisted to **localStorage** and the state will automatically sync to all tabs/pages of the browser. The storage key the data will be written to will be: `{responseType}-{authorizeUrl}-{clientId}-{scope}`. 
+After a successful authorization, data will get persisted to **localStorage** and the state will automatically sync to all tabs/pages of the browser. The storage key the data will be written to will be: `{responseType}-{authorizeUrl}-{clientId}-{scope}`.
 
 If you want to re-trigger the authorization flow just call `getAuth()` function again.
 
@@ -110,39 +109,40 @@ If you want to re-trigger the authorization flow just call `getAuth()` function 
 
 ## API
 
-- `function useOAuth2(options): {data, loading, error, getAuth}`
+-   `function useOAuth2(options): {data, loading, error, getAuth}`
 
 This is the hook that makes this package to work. `Options` is an object that contains the properties below
 
-- **authorizeUrl** (string): The 3rd party authorization URL (e.g https://accounts.google.com/o/oauth2/v2/auth).
-- **clientId** (string): The OAuth2 client id of your application.
-- **redirectUri** (string): Determines where the 3rd party API server redirects the user after the user completes the authorization flow. In our [example](#usage-example) the Popup is rendered on that redirectUri.
-- **scope** (string - _optional_): A list of scopes depending on your application needs.
-- **responseType** (string): Can be either **code** for _code authorization grant_ or **token** for _implicit grant_.
-- **extraQueryParameters** (string - _optional_): An object of extra parameters that you'd like to pass to the query part of the authorizeUrl, e.g {audience: "xyz"}.
-- **exchangeCodeForTokenServerURL** (string): This property is only used when using _code authorization grant_ flow (responseType = code). It specifies the API URL of your server that will get called immediately after the user completes the authorization flow. Read more [here](#what-is-the-purpose-of-exchangecodefortokenserverurl-for-authorization-code-flows).
-- **exchangeCodeForTokenMethod** (string - _optional_): Specifies the HTTP method that will be used for the code-for-token exchange to your server. Defaults to **POST**.
-- **onSuccess** (function): Called after a complete successful authorization flow.
-- **onError** (function): Called when an error occurs.
+-   **authorizeUrl** (string): The 3rd party authorization URL (e.g https://accounts.google.com/o/oauth2/v2/auth).
+-   **clientId** (string): The OAuth2 client id of your application.
+-   **redirectUri** (string): Determines where the 3rd party API server redirects the user after the user completes the authorization flow. In our [example](#usage-example) the Popup is rendered on that redirectUri.
+-   **scope** (string - _optional_): A list of scopes depending on your application needs.
+-   **responseType** (string): Can be either **code** for _code authorization grant_ or **token** for _implicit grant_.
+-   **extraQueryParameters** (string - _optional_): An object of extra parameters that you'd like to pass to the query part of the authorizeUrl, e.g {audience: "xyz"}.
+-   **exchangeCodeForTokenServerURL** (string): This property is only used when using _code authorization grant_ flow (responseType = code). It specifies the API URL of your server that will get called immediately after the user completes the authorization flow. Read more [here](#what-is-the-purpose-of-exchangecodefortokenserverurl-for-authorization-code-flows).
+-   **exchangeCodeForTokenMethod** (string - _optional_): Specifies the HTTP method that will be used for the code-for-token exchange to your server. Defaults to **POST**.
+-   **exchangeCodeForTokenBearerToken** (string - _optional_): Specifies the bearer token that will be sent for the code-for-token exchange to your server, if it has a `string` value. Defaults to `undefined`.
+-   **onSuccess** (function): Called after a complete successful authorization flow.
+-   **onError** (function): Called when an error occurs.
 
 **Returns**:
 
-- **data** (object): Consists of the retrieved auth data and generally will have the shape of `{access_token, token_type, expires_in}` (check [Typescript](#typescript) usage for providing custom shape).
-- **loading** (boolean): Is set to true while the authorization is taking place.
-- **error** (string): Is set when an error occurs.
-- **getAuth** (function): Call this function to trigger the authorization flow.
-- **logout** (function): Call this function to logout and clear all authorization data.
-- **isPersistent** (boolean): Property that returns false if localStorage is throwing an error and the data is stored only in-memory. Useful if you want to notify the user.
+-   **data** (object): Consists of the retrieved auth data and generally will have the shape of `{access_token, token_type, expires_in}` (check [Typescript](#typescript) usage for providing custom shape).
+-   **loading** (boolean): Is set to true while the authorization is taking place.
+-   **error** (string): Is set when an error occurs.
+-   **getAuth** (function): Call this function to trigger the authorization flow.
+-   **logout** (function): Call this function to logout and clear all authorization data.
+-   **isPersistent** (boolean): Property that returns false if localStorage is throwing an error and the data is stored only in-memory. Useful if you want to notify the user.
 
 ---
 
-- `function OAuthPopup(props)`
+-   `function OAuthPopup(props)`
 
-This is the component that will be rendered as a window Popup for as long as the authorization is taking place. You need to render this in a place where it does not disrupt the user flow. An ideal place is inside a `Route` component of `react-router-dom` as seen in the [usage example](#usage-example). 
+This is the component that will be rendered as a window Popup for as long as the authorization is taking place. You need to render this in a place where it does not disrupt the user flow. An ideal place is inside a `Route` component of `react-router-dom` as seen in the [usage example](#usage-example).
 
-Props consists of: 
+Props consists of:
 
-- **Component** (ReactElement - _optional_): You can optionally set a custom component to be rendered inside the Popup. By default it just displays a "Loading..." message.
+-   **Component** (ReactElement - _optional_): You can optionally set a custom component to be rendered inside the Popup. By default it just displays a "Loading..." message.
 
 ### Typescript
 
@@ -157,7 +157,7 @@ const useOAuth2: <TData = AuthTokenPayload>(props: Oauth2Props<TData>) => {
 }
 ```
 
-That means that generally the data will have the shape of `AuthTokenPayload` which consists of: 
+That means that generally the data will have the shape of `AuthTokenPayload` which consists of:
 
 ```
 token_type: string;
@@ -167,7 +167,7 @@ scope: string;
 refresh_token: string;
 ```
 
-And that also means that you can set the data type by using the hook like this: 
+And that also means that you can set the data type by using the hook like this:
 
 ```
 type MyCustomShapeData = {
@@ -185,4 +185,4 @@ You can run tests by calling
 npm test
 ```
 
-It will start a react-app (:3000) and  back-end server (:3001) and then it will run the tests with jest & puppeteer. 
+It will start a react-app (:3000) and back-end server (:3001) and then it will run the tests with jest & puppeteer.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ## Features
 
--   Usage with both `Implicit` and `Authorization Code` grant flows.
--   Seamlessly **exchanges code for token** via your backend API URL, for authorization code grant flows.
--   Works with **Popup** authorization.
--   Provides data and loading/error states via a hook.
--   **Persists data** to localStorage and automatically syncs auth state between tabs and/or browser windows.
+- Usage with both `Implicit` and `Authorization Code` grant flows.
+- Seamlessly **exchanges code for token** via your backend API URL, for authorization code grant flows.
+- Works with **Popup** authorization.
+- Provides data and loading/error states via a hook.
+- **Persists data** to localStorage and automatically syncs auth state between tabs and/or browser windows.
 
 ## Install
 
@@ -28,70 +28,71 @@ npm i @tasoskakour/react-use-oauth2
 
 ## Usage example
 
-_For authorization code flow:_
+*For authorization code flow:*
 
 ```js
-import { OAuth2Popup, useOAuth2 } from '@tasoskakour/react-use-oauth2';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { OAuth2Popup, useOAuth2 } from "@tasoskakour/react-use-oauth2";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 const Home = () => {
-	const { data, loading, error, getAuth, logout } = useOAuth2({
-		authorizeUrl: 'https://example.com/auth',
-		clientId: 'YOUR_CLIENT_ID',
-		redirectUri: `${document.location.origin}/callback`,
-		scope: 'YOUR_SCOPES',
-		responseType: 'code',
-		exchangeCodeForTokenServerURL: 'https://your-backend/token',
-		exchangeCodeForTokenMethod: 'POST',
-		onSuccess: (payload) => console.log('Success', payload),
-		onError: (error_) => console.log('Error', error_),
-	});
+  const { data, loading, error, getAuth, logout } = useOAuth2({
+    authorizeUrl: "https://example.com/auth",
+    clientId: "YOUR_CLIENT_ID",
+    redirectUri: `${document.location.origin}/callback`,
+    scope: "YOUR_SCOPES",
+    responseType: "code",
+    exchangeCodeForTokenServerURL: "https://your-backend/token",
+    exchangeCodeForTokenMethod: "POST",
+    onSuccess: (payload) => console.log("Success", payload),
+    onError: (error_) => console.log("Error", error_)
+  });
 
-	const isLoggedIn = Boolean(data?.access_token); // or whatever...
+  const isLoggedIn = Boolean(data?.access_token); // or whatever...
 
-	if (error) {
-		return <div>Error</div>;
-	}
+  if (error) {
+    return <div>Error</div>;
+  }
 
-	if (loading) {
-		return <div>Loading...</div>;
-	}
+  if (loading) {
+    return <div>Loading...</div>;
+  }
 
-	if (isLoggedIn) {
-		return (
-			<div>
-				<pre>{JSON.stringify(data)}</pre>
-				<button onClick={logout}>Logout</button>
-			</div>
-		);
-	}
+  if (isLoggedIn) {
+    return (
+      <div>
+        <pre>{JSON.stringify(data)}</pre>
+        <button onClick={logout}>Logout</button>
+      </div>
+    )
+  }
 
-	return (
-		<button style={{ margin: '24px' }} type="button" onClick={() => getAuth()}>
-			Login
-		</button>
-	);
+  return (
+    <button style={{ margin: "24px" }} type="button" onClick={() => getAuth()}>
+      Login
+    </button>
+  );
 };
 
 const App = () => {
-	return (
-		<BrowserRouter>
-			<Routes>
-				<Route element={<OAuthPopup />} path="/callback" />
-				<Route element={<Home />} path="/" />
-			</Routes>
-		</BrowserRouter>
-	);
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route element={<OAuthPopup />} path="/callback" />
+        <Route element={<Home />} path="/" />
+      </Routes>
+    </BrowserRouter>
+  );
 };
 ```
 
 ### What is the purpose of `exchangeCodeForTokenServerURL` for Authorization Code flows?
 
-Generally when we're working with authorization code flows, we need to _immediately_ **exchange** the retrieved _code_ with an actual _access token_, after a successful authorization. Most of the times this is needed for back-end apps, but there are many use cases this is useful for front-end apps as well.
+Generally when we're working with authorization code flows, we need to *immediately* **exchange** the retrieved *code* with an actual *access token*, after a successful authorization. Most of the times this is needed for back-end apps, but there are many use cases this is useful for front-end apps as well. 
 
-In order for the flow to be accomplished, the 3rd party provider we're authorizing against (e.g Google, Facebook etc), will provide an API call (e.g for Google is `https://oauth2.googleapis.com/token`) that we need to hit in order to exchange the code for an access token. However, this call requires the `client_secret` of your 3rd party app as a parameter to work - a secret that you cannot expose to your front-end app.
+In order for the flow to be accomplished, the 3rd party provider we're authorizing against (e.g Google, Facebook etc), will provide an API call (e.g for Google is `https://oauth2.googleapis.com/token`) that we need to hit in order to exchange the code for an access token. However, this call requires the `client_secret` of your 3rd party app as a parameter to work - a secret that you cannot expose to your front-end app. 
 
-That's why you need to proxy this call to your back-end and `exchangeCodeForTokenServerURL` is the API URL of your back-end route that will take care of this. The request parameters that will get passed along as **query parameters** are `{ code, client_id, grant_type, redirect_uri, state }`. By default this will be a **POST** request but you can change it with the `exchangeCodeForTokenMethod` property. In case your backend requires a bearer token for authorization, you can pass it through `exchangeCodeForTokenBearerToken`.
+That's why you need to proxy this call to your back-end and `exchangeCodeForTokenServerURL` is the API URL of your back-end route that will take care of this. The request parameters that will get passed along as **query parameters** are `{ code, client_id, grant_type, redirect_uri, state }`. By default this will be a **POST** request but you can change it with the `exchangeCodeForTokenMethod` property. 
+
 
 You can read more about "Exchanging authorization code for refresh and access tokens" in [Google OAuth2 documentation](https://developers.google.com/identity/protocols/oauth2/web-server#exchange-authorization-code).
 
@@ -101,7 +102,7 @@ With an implicit grant flow things are much simpler as the 3rd-party provider im
 
 ### Data persistence
 
-After a successful authorization, data will get persisted to **localStorage** and the state will automatically sync to all tabs/pages of the browser. The storage key the data will be written to will be: `{responseType}-{authorizeUrl}-{clientId}-{scope}`.
+After a successful authorization, data will get persisted to **localStorage** and the state will automatically sync to all tabs/pages of the browser. The storage key the data will be written to will be: `{responseType}-{authorizeUrl}-{clientId}-{scope}`. 
 
 If you want to re-trigger the authorization flow just call `getAuth()` function again.
 
@@ -109,40 +110,39 @@ If you want to re-trigger the authorization flow just call `getAuth()` function 
 
 ## API
 
--   `function useOAuth2(options): {data, loading, error, getAuth}`
+- `function useOAuth2(options): {data, loading, error, getAuth}`
 
 This is the hook that makes this package to work. `Options` is an object that contains the properties below
 
--   **authorizeUrl** (string): The 3rd party authorization URL (e.g https://accounts.google.com/o/oauth2/v2/auth).
--   **clientId** (string): The OAuth2 client id of your application.
--   **redirectUri** (string): Determines where the 3rd party API server redirects the user after the user completes the authorization flow. In our [example](#usage-example) the Popup is rendered on that redirectUri.
--   **scope** (string - _optional_): A list of scopes depending on your application needs.
--   **responseType** (string): Can be either **code** for _code authorization grant_ or **token** for _implicit grant_.
--   **extraQueryParameters** (string - _optional_): An object of extra parameters that you'd like to pass to the query part of the authorizeUrl, e.g {audience: "xyz"}.
--   **exchangeCodeForTokenServerURL** (string): This property is only used when using _code authorization grant_ flow (responseType = code). It specifies the API URL of your server that will get called immediately after the user completes the authorization flow. Read more [here](#what-is-the-purpose-of-exchangecodefortokenserverurl-for-authorization-code-flows).
--   **exchangeCodeForTokenMethod** (string - _optional_): Specifies the HTTP method that will be used for the code-for-token exchange to your server. Defaults to **POST**.
--   **exchangeCodeForTokenBearerToken** (string - _optional_): Specifies the bearer token that will be sent for the code-for-token exchange to your server, if it has a `string` value. Defaults to `undefined`.
--   **onSuccess** (function): Called after a complete successful authorization flow.
--   **onError** (function): Called when an error occurs.
+- **authorizeUrl** (string): The 3rd party authorization URL (e.g https://accounts.google.com/o/oauth2/v2/auth).
+- **clientId** (string): The OAuth2 client id of your application.
+- **redirectUri** (string): Determines where the 3rd party API server redirects the user after the user completes the authorization flow. In our [example](#usage-example) the Popup is rendered on that redirectUri.
+- **scope** (string - _optional_): A list of scopes depending on your application needs.
+- **responseType** (string): Can be either **code** for _code authorization grant_ or **token** for _implicit grant_.
+- **extraQueryParameters** (string - _optional_): An object of extra parameters that you'd like to pass to the query part of the authorizeUrl, e.g {audience: "xyz"}.
+- **exchangeCodeForTokenServerURL** (string): This property is only used when using _code authorization grant_ flow (responseType = code). It specifies the API URL of your server that will get called immediately after the user completes the authorization flow. Read more [here](#what-is-the-purpose-of-exchangecodefortokenserverurl-for-authorization-code-flows).
+- **exchangeCodeForTokenMethod** (string - _optional_): Specifies the HTTP method that will be used for the code-for-token exchange to your server. Defaults to **POST**.
+- **onSuccess** (function): Called after a complete successful authorization flow.
+- **onError** (function): Called when an error occurs.
 
 **Returns**:
 
--   **data** (object): Consists of the retrieved auth data and generally will have the shape of `{access_token, token_type, expires_in}` (check [Typescript](#typescript) usage for providing custom shape).
--   **loading** (boolean): Is set to true while the authorization is taking place.
--   **error** (string): Is set when an error occurs.
--   **getAuth** (function): Call this function to trigger the authorization flow.
--   **logout** (function): Call this function to logout and clear all authorization data.
--   **isPersistent** (boolean): Property that returns false if localStorage is throwing an error and the data is stored only in-memory. Useful if you want to notify the user.
+- **data** (object): Consists of the retrieved auth data and generally will have the shape of `{access_token, token_type, expires_in}` (check [Typescript](#typescript) usage for providing custom shape).
+- **loading** (boolean): Is set to true while the authorization is taking place.
+- **error** (string): Is set when an error occurs.
+- **getAuth** (function): Call this function to trigger the authorization flow.
+- **logout** (function): Call this function to logout and clear all authorization data.
+- **isPersistent** (boolean): Property that returns false if localStorage is throwing an error and the data is stored only in-memory. Useful if you want to notify the user.
 
 ---
 
--   `function OAuthPopup(props)`
+- `function OAuthPopup(props)`
 
-This is the component that will be rendered as a window Popup for as long as the authorization is taking place. You need to render this in a place where it does not disrupt the user flow. An ideal place is inside a `Route` component of `react-router-dom` as seen in the [usage example](#usage-example).
+This is the component that will be rendered as a window Popup for as long as the authorization is taking place. You need to render this in a place where it does not disrupt the user flow. An ideal place is inside a `Route` component of `react-router-dom` as seen in the [usage example](#usage-example). 
 
-Props consists of:
+Props consists of: 
 
--   **Component** (ReactElement - _optional_): You can optionally set a custom component to be rendered inside the Popup. By default it just displays a "Loading..." message.
+- **Component** (ReactElement - _optional_): You can optionally set a custom component to be rendered inside the Popup. By default it just displays a "Loading..." message.
 
 ### Typescript
 
@@ -157,7 +157,7 @@ const useOAuth2: <TData = AuthTokenPayload>(props: Oauth2Props<TData>) => {
 }
 ```
 
-That means that generally the data will have the shape of `AuthTokenPayload` which consists of:
+That means that generally the data will have the shape of `AuthTokenPayload` which consists of: 
 
 ```
 token_type: string;
@@ -167,7 +167,7 @@ scope: string;
 refresh_token: string;
 ```
 
-And that also means that you can set the data type by using the hook like this:
+And that also means that you can set the data type by using the hook like this: 
 
 ```
 type MyCustomShapeData = {
@@ -185,4 +185,4 @@ You can run tests by calling
 npm test
 ```
 
-It will start a react-app (:3000) and back-end server (:3001) and then it will run the tests with jest & puppeteer.
+It will start a react-app (:3000) and  back-end server (:3001) and then it will run the tests with jest & puppeteer. 

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -13,7 +13,6 @@ export type TResponseTypeBasedProps<TData> =
 			responseType: 'code';
 			exchangeCodeForTokenServerURL: string;
 			exchangeCodeForTokenMethod?: 'POST' | 'GET';
-			exchangeCodeForTokenBearerToken?: string;
 			onSuccess?: (payload: TData) => void; // TODO as this payload will be custom
 			// TODO Adjust payload type
 	  }

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -13,6 +13,7 @@ export type TResponseTypeBasedProps<TData> =
 			responseType: 'code';
 			exchangeCodeForTokenServerURL: string;
 			exchangeCodeForTokenMethod?: 'POST' | 'GET';
+			exchangeCodeForTokenHeaders?: Record<string, any>;
 			onSuccess?: (payload: TData) => void; // TODO as this payload will be custom
 			// TODO Adjust payload type
 	  }

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -13,6 +13,7 @@ export type TResponseTypeBasedProps<TData> =
 			responseType: 'code';
 			exchangeCodeForTokenServerURL: string;
 			exchangeCodeForTokenMethod?: 'POST' | 'GET';
+			exchangeCodeForTokenBearerToken?: string;
 			onSuccess?: (payload: TData) => void; // TODO as this payload will be custom
 			// TODO Adjust payload type
 	  }

--- a/src/components/use-oauth2.test.ts
+++ b/src/components/use-oauth2.test.ts
@@ -169,7 +169,7 @@ describe('useOAuth2', () => {
 					REDIRECT_URI,
 					generatedState as string
 				),
-				{ method: 'POST', headers: {} },
+				{ method: 'POST' },
 			]);
 			expect(result.current.loading).toBe(false);
 			expect(result.current.error).toBe(null);

--- a/src/components/use-oauth2.test.ts
+++ b/src/components/use-oauth2.test.ts
@@ -15,6 +15,10 @@ const REDIRECT_URI = 'http://mockRedirectUri';
 const SCOPE = 'some-scope';
 const EXTRA_QUERY_PARAMETERS = { a: 1, b: 2 };
 const EXCHANGE_CODE_FOR_TOKEN_SERVER_URL = 'http://mockExchangeCodeForTokenServerURL';
+const EXCHANGE_CODE_FOR_TOKEN_SERVER_HEADERS = {
+	Authorization:
+		'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+};
 
 jest.mock('./tools', () => {
 	const originalModule = jest.requireActual('./tools');
@@ -127,6 +131,7 @@ describe('useOAuth2', () => {
 				responseType: 'code',
 				scope: SCOPE,
 				exchangeCodeForTokenServerURL: EXCHANGE_CODE_FOR_TOKEN_SERVER_URL,
+				exchangeCodeForTokenHeaders: EXCHANGE_CODE_FOR_TOKEN_SERVER_HEADERS,
 				extraQueryParameters: EXTRA_QUERY_PARAMETERS,
 				onSuccess,
 			})
@@ -169,7 +174,10 @@ describe('useOAuth2', () => {
 					REDIRECT_URI,
 					generatedState as string
 				),
-				{ method: 'POST', headers: {} },
+				{
+					method: 'POST',
+					headers: EXCHANGE_CODE_FOR_TOKEN_SERVER_HEADERS,
+				},
 			]);
 			expect(result.current.loading).toBe(false);
 			expect(result.current.error).toBe(null);

--- a/src/components/use-oauth2.test.ts
+++ b/src/components/use-oauth2.test.ts
@@ -169,7 +169,7 @@ describe('useOAuth2', () => {
 					REDIRECT_URI,
 					generatedState as string
 				),
-				{ method: 'POST' },
+				{ method: 'POST', headers: {} },
 			]);
 			expect(result.current.loading).toBe(false);
 			expect(result.current.error).toBe(null);

--- a/src/components/use-oauth2.ts
+++ b/src/components/use-oauth2.ts
@@ -42,6 +42,8 @@ export const useOAuth2 = <TData = TAuthTokenPayload>(props: TOauth2Props<TData>)
 	const exchangeCodeForTokenServerURL =
 		responseType === 'code' && props.exchangeCodeForTokenServerURL;
 	const exchangeCodeForTokenMethod = responseType === 'code' && props.exchangeCodeForTokenMethod;
+	const exchangeCodeForTokenBearerToken =
+		responseType === 'code' && props.exchangeCodeForTokenBearerToken;
 
 	const getAuth = useCallback(() => {
 		// 1. Init
@@ -84,6 +86,11 @@ export const useOAuth2 = <TData = TAuthTokenPayload>(props: TOauth2Props<TData>)
 				} else {
 					let payload = message?.data?.payload;
 					if (responseType === 'code' && exchangeCodeForTokenServerURL) {
+						console.log({
+							...(exchangeCodeForTokenBearerToken && {
+								Authorization: `Bearer ${exchangeCodeForTokenBearerToken}`,
+							}),
+						});
 						const response = await fetch(
 							formatExchangeCodeForTokenServerURL(
 								exchangeCodeForTokenServerURL,
@@ -96,6 +103,11 @@ export const useOAuth2 = <TData = TAuthTokenPayload>(props: TOauth2Props<TData>)
 								method:
 									exchangeCodeForTokenMethod ||
 									DEFAULT_EXCHANGE_CODE_FOR_TOKEN_METHOD,
+								headers: {
+									...(exchangeCodeForTokenBearerToken && {
+										Authorization: `Bearer ${exchangeCodeForTokenBearerToken}`,
+									}),
+								},
 							}
 						);
 						payload = await response.json();

--- a/src/components/use-oauth2.ts
+++ b/src/components/use-oauth2.ts
@@ -42,6 +42,8 @@ export const useOAuth2 = <TData = TAuthTokenPayload>(props: TOauth2Props<TData>)
 	const exchangeCodeForTokenServerURL =
 		responseType === 'code' && props.exchangeCodeForTokenServerURL;
 	const exchangeCodeForTokenMethod = responseType === 'code' && props.exchangeCodeForTokenMethod;
+	const exchangeCodeForTokenHeaders =
+		responseType === 'code' && props.exchangeCodeForTokenHeaders;
 
 	const getAuth = useCallback(() => {
 		// 1. Init
@@ -96,6 +98,7 @@ export const useOAuth2 = <TData = TAuthTokenPayload>(props: TOauth2Props<TData>)
 								method:
 									exchangeCodeForTokenMethod ||
 									DEFAULT_EXCHANGE_CODE_FOR_TOKEN_METHOD,
+								headers: exchangeCodeForTokenHeaders || {},
 							}
 						);
 						payload = await response.json();
@@ -149,6 +152,7 @@ export const useOAuth2 = <TData = TAuthTokenPayload>(props: TOauth2Props<TData>)
 		responseType,
 		exchangeCodeForTokenServerURL,
 		exchangeCodeForTokenMethod,
+		exchangeCodeForTokenHeaders,
 		onSuccess,
 		onError,
 		setUI,

--- a/src/components/use-oauth2.ts
+++ b/src/components/use-oauth2.ts
@@ -42,8 +42,6 @@ export const useOAuth2 = <TData = TAuthTokenPayload>(props: TOauth2Props<TData>)
 	const exchangeCodeForTokenServerURL =
 		responseType === 'code' && props.exchangeCodeForTokenServerURL;
 	const exchangeCodeForTokenMethod = responseType === 'code' && props.exchangeCodeForTokenMethod;
-	const exchangeCodeForTokenBearerToken =
-		responseType === 'code' && props.exchangeCodeForTokenBearerToken;
 
 	const getAuth = useCallback(() => {
 		// 1. Init
@@ -86,11 +84,6 @@ export const useOAuth2 = <TData = TAuthTokenPayload>(props: TOauth2Props<TData>)
 				} else {
 					let payload = message?.data?.payload;
 					if (responseType === 'code' && exchangeCodeForTokenServerURL) {
-						console.log({
-							...(exchangeCodeForTokenBearerToken && {
-								Authorization: `Bearer ${exchangeCodeForTokenBearerToken}`,
-							}),
-						});
 						const response = await fetch(
 							formatExchangeCodeForTokenServerURL(
 								exchangeCodeForTokenServerURL,
@@ -103,11 +96,6 @@ export const useOAuth2 = <TData = TAuthTokenPayload>(props: TOauth2Props<TData>)
 								method:
 									exchangeCodeForTokenMethod ||
 									DEFAULT_EXCHANGE_CODE_FOR_TOKEN_METHOD,
-								headers: {
-									...(exchangeCodeForTokenBearerToken && {
-										Authorization: `Bearer ${exchangeCodeForTokenBearerToken}`,
-									}),
-								},
 							}
 						);
 						payload = await response.json();


### PR DESCRIPTION
I've added the support of a bearer token for the requests to the token server. I require this enhancement, as my backend server requires authentication/authorization to proceed with the requests.

I would appreciate it if you could pull that enhancement into your codebase and publish a new library/npm package version.