### PR TITLE
Explicitly specify target storage for state variables.

### DIFF
--- a/src/components/OAuthPopup.tsx
+++ b/src/components/OAuthPopup.tsx
@@ -23,7 +23,7 @@ export const OAuthPopup = ({
 		const opener = window?.opener;
 
 		if (isWindowOpener(opener)) {
-			const stateOk = state && checkState(state);
+			const stateOk = state && checkState(opener.sessionStorage, state);
 
 			if (!error && stateOk) {
 				openerPostMessage(opener, {

--- a/src/components/tools.test.ts
+++ b/src/components/tools.test.ts
@@ -65,7 +65,7 @@ describe('generateState', () => {
 
 describe('saveState', () => {
 	it('should save the state to sessionStorage', () => {
-		saveState('abc123');
+		saveState(sessionStorage, 'abc123');
 		expect(sessionStorage.getItem(OAUTH_STATE_KEY)).toEqual('abc123');
 	});
 });
@@ -73,7 +73,7 @@ describe('saveState', () => {
 describe('removeState', () => {
 	it('should remove the state from sessionStorage', () => {
 		sessionStorage.setItem(OAUTH_STATE_KEY, 'abc123');
-		removeState();
+		removeState(sessionStorage);
 		expect(sessionStorage.getItem(OAUTH_STATE_KEY)).toBeNull();
 	});
 });
@@ -81,12 +81,12 @@ describe('removeState', () => {
 describe('checkState', () => {
 	it('should return true if the received state matches the saved state', () => {
 		sessionStorage.setItem(OAUTH_STATE_KEY, 'abc123');
-		expect(checkState('abc123')).toBe(true);
+		expect(checkState(sessionStorage, 'abc123')).toBe(true);
 	});
 
 	it('should return false if the received state does not match the saved state', () => {
 		sessionStorage.setItem(OAUTH_STATE_KEY, 'abc123');
-		expect(checkState('def456')).toBe(false);
+		expect(checkState(sessionStorage, 'def456')).toBe(false);
 	});
 });
 

--- a/src/components/tools.ts
+++ b/src/components/tools.ts
@@ -41,16 +41,16 @@ export const generateState = () => {
 	return randomState;
 };
 
-export const saveState = (state: string) => {
-	sessionStorage.setItem(OAUTH_STATE_KEY, state);
+export const saveState = (storage: Storage, state: string) => {
+	storage.setItem(OAUTH_STATE_KEY, state);
 };
 
-export const removeState = () => {
-	sessionStorage.removeItem(OAUTH_STATE_KEY);
+export const removeState = (storage: Storage) => {
+	storage.removeItem(OAUTH_STATE_KEY);
 };
 
-export const checkState = (receivedState: string) => {
-	const state = sessionStorage.getItem(OAUTH_STATE_KEY);
+export const checkState = (storage: Storage, receivedState: string) => {
+	const state = storage.getItem(OAUTH_STATE_KEY);
 	return state === receivedState;
 };
 
@@ -83,7 +83,7 @@ export const cleanup = (
 ) => {
 	clearInterval(intervalRef.current);
 	if (popupRef.current && typeof popupRef.current.close === 'function') closePopup(popupRef);
-	removeState();
+	removeState(sessionStorage);
 	window.removeEventListener('message', handleMessageListener);
 };
 

--- a/src/components/use-oauth2.ts
+++ b/src/components/use-oauth2.ts
@@ -54,7 +54,7 @@ export const useOAuth2 = <TData = TAuthTokenPayload>(props: TOauth2Props<TData>)
 
 		// 2. Generate and save state
 		const state = generateState();
-		saveState(state);
+		saveState(sessionStorage, state);
 
 		// 3. Open popup
 		popupRef.current = openPopup(


### PR DESCRIPTION
This package works great for authentication in both Chrome and Edge. In Vivaldi (another Chromium form), however, I encountered an issue where the page's session storage is not by default copied to the popup window. This causes a state validation failure since the component in the popup window is what checks to ensure the fragment's state matches what was originally generated.

I am able to work around this by explicitly specifying to check against `opener.sessionStorage` instead of `sessionStorage`.

In my first screenshot below (using Google Chrome), you can see the state showing the state variable present in both windows, but in the second (using Vivaldi), it isn't.

![image](https://github.com/tasoskakour/react-use-oauth2/assets/75811601/a601ecec-46e9-4463-9d76-7208bca8fb1d)

![image](https://github.com/tasoskakour/react-use-oauth2/assets/75811601/a76a5637-5640-4a91-b866-51a6e1c79fa3)

More details from `useOauth` function:

Chrome
![image](https://github.com/tasoskakour/react-use-oauth2/assets/75811601/11acb409-2e14-467c-bfd1-c3568b3042ef)

Vivaldi
![image](https://github.com/tasoskakour/react-use-oauth2/assets/75811601/b5c8c7f8-4f16-4038-b0e6-34d4059cd53f)
