### PR TITLE
Call onError when exchangeCodeForTokenQuery... has error.

### DIFF
--- a/src/components/use-oauth2.ts
+++ b/src/components/use-oauth2.ts
@@ -133,6 +133,7 @@ export const useOAuth2 = <TData = TAuthTokenPayload>(props: TOauth2Props<TData>)
 					loading: false,
 					error: genericError.toString(),
 				});
+				if (onError) await onError(genericError.toString());
 			} finally {
 				// Clear stuff ...
 				cleanup(intervalRef, popupRef, handleMessageListener);


### PR DESCRIPTION
Simple patch, onError is not currently called for errors in the 'second step' of exchanging the code.  Unsure if this was intentional or an oversight.